### PR TITLE
Reverted bug from error checking

### DIFF
--- a/RailEngine/Assets/Editor/LevelExport.cs
+++ b/RailEngine/Assets/Editor/LevelExport.cs
@@ -27,8 +27,8 @@ public class LevelExport : EditorWindow
 
     static void Init()
     {
-        if (LevelTransitionCheck.IsSceneOrigional)
-        {
+        //if (LevelTransitionCheck.IsSceneOrigional)
+        //{
             if (Selection.activeGameObject == null)
             {
                 System.Media.SystemSounds.Hand.Play();
@@ -62,12 +62,12 @@ public class LevelExport : EditorWindow
                     window.Show();
                 }
             }
-        }
-        else
-        {
-            EditorUtility.DisplayDialog("Scene Transitions not allowed",
-                "Level Export does not work during runtime after scene transitions.", "Acknowledge");
-        }
+        //}
+        //else
+        //{
+        //    EditorUtility.DisplayDialog("Scene Transitions not allowed",
+        //        "Level Export does not work during runtime after scene transitions.", "Acknowledge");
+        //}
     }
 
     void OnGUI()

--- a/RailEngine/Assets/Editor/LevelTransitionCheck.cs
+++ b/RailEngine/Assets/Editor/LevelTransitionCheck.cs
@@ -33,4 +33,5 @@ public static class LevelTransitionCheck
     {
         IsSceneOrigional = false;
     }
+
 }


### PR DESCRIPTION
Error checking for scene transitions caused level export to quit working
completely. Reverted change.
